### PR TITLE
Fix wrong order of ip_real and host for dnsmasq

### DIFF
--- a/phpipam-hosts
+++ b/phpipam-hosts
@@ -407,9 +407,9 @@ try:
 
         elif args.format == 'dnsmasq':
           if not mac:
-            entry = '{},{}\n'.format(host, ip_real)
+            entry = '{},{}\n'.format(ip_real, host)
           else:
-            entry = '{}{},{},{}\n'.format(comment, mac, host, ip_real)
+            entry = '{}{},{},{}\n'.format(comment, mac, ip_real, host)
           output = output + entry
 
         elif args.format == 'hosts':


### PR DESCRIPTION
I had to flip "ip_real" and "host" otherwise dnsmasq would complain:

Jul 17 18:14:25 firewall dnsmasq[15881]: bad hex constant at line XX of /etc/hosts_phpipam
Jul 17 18:14:25 firewall dnsmasq[15881]: bad DHCP host name at line XX of /etc/hosts_phpipam

From man dnsmasq - version 2.80:
-G, --dhcp-host=[<hwaddr>][,id:<client_id>|*][,set:<tag>][,<ipaddr>][,<hostname>][,<lease_time>][,ignore]

Note hwaddr, ip, hostname

Great script btw. thanks :>